### PR TITLE
Patch API Appellations viticoles pour FranceAgrimer

### DIFF
--- a/controllers/aoc.js
+++ b/controllers/aoc.js
@@ -17,7 +17,7 @@ var inQuery = Handlebars.compile(`
         FROM
             (SELECT ST_SetSRID(ST_GeomFromGeoJSON('%s'), 4326) geom) input,
             appellation
-        WHERE appellation.insee IN (%L) AND (appellation.geom IS NULL OR ST_Intersects(appellation.geom, input.geom));
+        WHERE appellation.insee IN (%L);
 `);
 
 function buildSQLQuery(options) {

--- a/controllers/aoc.js
+++ b/controllers/aoc.js
@@ -51,11 +51,18 @@ exports.in = function(req, res, next) {
         return res.send({
             type: 'FeatureCollection',
             features: result.rows.map(function (row) {
-                return {
+                const feature = {
                     type: 'Feature',
                     geometry: JSON.parse(row.geom),
                     properties: _.omit(row, 'geom')
                 };
+                if (row.granularite === 'commune' && !row.instruction_obligatoire) {
+                    const commune = _.find(req.intersectedCommunes, { insee: row.insee });
+                    feature.properties.area = commune.intersect_area;
+                    feature.properties.contains = commune.contains;
+                    feature.geometry = JSON.parse(commune.geom);
+                }
+                return feature;
             })
         });
     });

--- a/helpers/communes.js
+++ b/helpers/communes.js
@@ -7,7 +7,12 @@ function intersects(options) {
         'osm': {
             prepareQuery: function (geometry) {
                 return format(`
-                    SELECT nom, insee, ST_Area(ST_Intersection(input.geom, communes.geom)::geography) / 10000 AS intersect_area
+                    SELECT
+                        nom,
+                        insee,
+                        ST_Contains(input.geom, communes.geom) AS contains,
+                        ST_Area(ST_Intersection(input.geom, communes.geom)::geography) / 10000 AS intersect_area,
+                        ST_AsGeoJSON(communes.geom) AS geom,
                     FROM
                         communes,
                         (SELECT ST_SetSRID(ST_GeomFromGeoJSON('%s'), 4326) geom) input
@@ -18,7 +23,12 @@ function intersects(options) {
         'ign-parcellaire': {
             prepareQuery: function (geometry) {
                 return format(`
-                    SELECT NOM_COM as nom, CODE_INSEE as insee, ST_Area(ST_Intersection(input.geom, communes_ign.geom)::geography) / 10000 AS intersect_area
+                    SELECT
+                        NOM_COM as nom,
+                        CODE_INSEE as insee,
+                        ST_Contains(input.geom, communes_ign.geom) AS contains,
+                        ST_Area(ST_Intersection(input.geom, communes_ign.geom)::geography) / 10000 AS intersect_area,
+                        ST_AsGeoJSON(communes_ign.geom) AS geom
                     FROM
                         communes_ign,
                         (SELECT ST_SetSRID(ST_GeomFromGeoJSON('%s'), 4326) geom) input

--- a/server.js
+++ b/server.js
@@ -30,7 +30,6 @@ function pgClient(req, res, next) {
 
 /* Routes */
 app.post('/aoc/api/beta/aoc/in', pgClient, communesHelper.intersects({ ref: 'ign-parcellaire' }), aoc.in);
-// app.get('/aoc/api/beta/aoc/bbox', pgClient, aoc.bbox);
 app.get('/codes-postaux/communes/:codePostal', codesPostaux.communes);
 app.post('/quartiers-prioritaires/search', pgClient, qp.search);
 


### PR DESCRIPTION
Action du plan #4 

Cette PR contient des ajustements négociés en direct avec FranceAgrimer.

Nous sommes conscients du caractère ultra-spécifique de ces changements que nous sommes forcés de faire pour des raisons historiques.

__Cette API a vocation à être gelée et sera complétée par une nouvelle API__ mieux pensée et surtout cohérente avec le reste d'API.
Pour la même raison __cette API ne sera pas documentée avec les autres__, mais la nouvelle le sera.

__Liste des changements :__
- L'API retourne désormais toutes les appellations qui intersectent les communes qui intersectent le polygone de la requête. Avant elle retournait les appellations qui intersectent le polygone.

- Lorsqu'on trouve une appellation de segment 3 ou 4 (à la commune), on recopie les informations de l'intersection avec la commune ainsi que la géométrie dans l'appellation.

- Les plugins Communes retournent désormais la géométrie et l'indicateur d'inclusion, par défaut.

Autre changement (mineur) : suppression de l'API de recherche par BBOX, qui n'était pas utilisée par FranceAgrimer.
