### PR TITLE
Migration des scripts d'import

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,8 @@ module.exports = function (grunt) {
     const sourceFiles = {
         qp: refDataDir + '/qp-politiquedelaville-shp.zip',
         'communes-ign-metrocorse': refDataDir + '/COMMUNE_PARCELLAIRE_METROCORSE.zip',
-        'communes-ign-reunion': refDataDir + '/COMMUNE_PARCELLAIRE_REUNION.zip'
+        'communes-ign-reunion': refDataDir + '/COMMUNE_PARCELLAIRE_REUNION.zip',
+        'communes-osm': refDataDir + '/communes-20150101-5m-shp.zip'
     };
 
     const importableLayers = {
@@ -33,6 +34,11 @@ module.exports = function (grunt) {
             convertToWgs84: true,
             createTable: 'NO',
             pgClientEncoding: 'LATIN1'
+        },
+        'communes-osm': {
+            dataSource: '/vsizip/communes-20150101-5m-shp.zip',
+            layerName: 'communes',
+            select: 'insee,nom'
         }
     };
 
@@ -58,6 +64,7 @@ module.exports = function (grunt) {
                     ];
                     if (config.append) ogrOptions.push('-append');
                     if (config.convertToWgs84) ogrOptions.push('-t_srs EPSG:4326');
+                    if (config.select) ogrOptions.push('-select ' + config.select);
 
                     const psqlOptions = [
                         '-h localhost',
@@ -97,9 +104,15 @@ module.exports = function (grunt) {
         'shell:importpg:communes-ign-reunion'
     ]);
 
+    grunt.registerTask('import-communes-osm', [
+        'shell:wget:communes-osm',
+        'shell:importpg:communes-osm'
+    ]);
+
     grunt.registerTask('import', [
         'import-qp',
-        'import-communes-ign'
+        'import-communes-ign',
+        'import-communes-osm'
     ]);
 
 };

--- a/sql/prepare-appellations.sql
+++ b/sql/prepare-appellations.sql
@@ -1,0 +1,23 @@
+-- Suppression des géométries des segments 3 et 4
+UPDATE Appellation SET geom = NULL WHERE segment IN ('3', '4');
+
+-- Correction des géométries incorrectes
+UPDATE Appellation SET geom = ST_Buffer(geom, 0) WHERE geom IS NOT NULL AND NOT ST_IsValid(geom);
+
+-- Enrichissement du schéma de la table
+CREATE TYPE type_granularite_appellation AS ENUM('commune', 'exacte');
+
+ALTER TABLE Appellation ADD COLUMN instruction_obligatoire boolean;
+ALTER TABLE Appellation ADD COLUMN granularite type_granularite_appellation;
+
+-- Enrichissement des données
+UPDATE Appellation SET instruction_obligatoire = FALSE;
+UPDATE Appellation SET granularite = 'exacte' WHERE segment = '1';
+UPDATE Appellation SET granularite = 'commune' WHERE segment IN ('3', '4');
+
+-- Marquage de l'appellation Sable de Camargue
+UPDATE Appellation SET instruction_obligatoire = TRUE WHERE IDApp = '1022';
+
+-- Création des indexes
+CREATE INDEX appellations_geom_gist ON Appellation USING GIST (geom);
+CREATE INDEX appellations_insee ON Appellation USING btree (insee);


### PR DESCRIPTION
Voilà j'ai migré les scripts d'import des __appellations viticoles__ et des __communes__ sur le même modèle que les __quartiers prioritaires__.

Le fichier contenant les __appellations viticoles__ est un peu gros, ce qui explique le durée de l'import. Heureusement les prochaines livraisons seront plus compactes.

On pourra aussi envisager faire un _dossier_ `test` plus léger sur le serveur contenant les données brutes.

NB : À partir de maintenant, le dépôt [apicarto-data](https://github.com/sgmap/apicarto-data) peut être considéré comme obsolète.