### PR TITLE
Document engine dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   ],
   "repository": "sgmap/apicarto",
   "license": "AGPL-3.0",
+  "engines": {
+    "node": ">=4",
+    "npm": ">=2"
+  },
   "dependencies": {
     "body-parser": "^1.14.1",
     "codes-postaux": "^1.0.1",


### PR DESCRIPTION
Avoid #12.

When installing, this changeset will have NPM output the following message:

```
npm WARN engine apicarto@0.2.0: wanted: {"node":">=4","npm":">=2"} (current: {"node":"0.10.40","npm":"2.14.4"})
```

I did not add `engineStrict` since the module could be `require`d through Babel at runtime, and so installing it should be supported. The fact that `engineStrict` is removed in NPM3 was not a valid reason for not using it, since we are targeting people with NPM<3.