### PR TITLE
Mise à jour du processus d'import des appellations viticoles

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,19 +13,12 @@ module.exports = function (grunt) {
         'communes-ign-metrocorse': refDataDir + '/COMMUNE_PARCELLAIRE_METROCORSE.zip',
         'communes-ign-reunion': refDataDir + '/COMMUNE_PARCELLAIRE_REUNION.zip',
         'communes-osm': refDataDir + '/communes-20150101-5m-shp.zip',
-        'appellations-viticoles': refDataDir + '/Appellation20151112.zip'
+        'appellations-viticoles': refDataDir + '/Appellation_20151207.zip'
     };
 
-    const rmdir = {
-        'appellations-viticoles': 'Appellation/'
-    };
+    const rmdir = {};
 
-    const unzip = {
-        'appellations-viticoles': {
-            src: 'Appellation20151112.zip',
-            dest: 'Appellation'
-        }
-    };
+    const unzip = {};
 
     const runpg = {
         'appellations-viticoles': 'prepare-appellations.sql'
@@ -57,11 +50,12 @@ module.exports = function (grunt) {
             select: 'insee,nom'
         },
         'appellations-viticoles': {
-            dataSource: 'Appellation/Appellation.TAB',
+            dataSource: '/vsizip/Appellation_20151207.zip',
             layerName: 'appellation',
             convertToWgs84: true,
             spatialIndex: 'NO',
-            pgClientEncoding: 'LATIN1'
+            pgClientEncoding: 'LATIN1',
+            append: true
         }
     };
 
@@ -155,10 +149,8 @@ module.exports = function (grunt) {
 
     grunt.registerTask('import-appellations-viticoles', [
         'shell:wget:appellations-viticoles',
-        'shell:unzip:appellations-viticoles',
         'shell:importpg:appellations-viticoles',
-        'shell:runpg:appellations-viticoles',
-        'shell:rmdir:appellations-viticoles'
+        'shell:runpg:appellations-viticoles'
     ]);
 
     grunt.registerTask('import', [

--- a/sql/prepare-appellations.sql
+++ b/sql/prepare-appellations.sql
@@ -1,8 +1,5 @@
--- Suppression des géométries des segments 3 et 4
-UPDATE Appellation SET geom = NULL WHERE segment IN ('3', '4');
-
--- Correction des géométries incorrectes
-UPDATE Appellation SET geom = ST_Buffer(geom, 0) WHERE geom IS NOT NULL AND NOT ST_IsValid(geom);
+-- Renommage de la colonne dont le nom est tronqué
+ALTER TABLE Appellation RENAME appellatio TO appellation;
 
 -- Enrichissement du schéma de la table
 CREATE TYPE type_granularite_appellation AS ENUM('commune', 'exacte');


### PR DESCRIPTION
FranceAgrimer a modifié son processus d'extraction des données, notamment pour améliorer la qualité de sortie.

Désormais ils fournissent une archive ZIP contenant deux jeux de données au format Shapefile :
* un shapefile contenant les appellations segment 1 vectorisées
* un shapefile contenant les appellations segment 1 non-vectorisées et les appellations segment 3 et 4

Le passage au format Shapefile zippé permet une simplification du processus d'import puisque l'étape de désarchivage est prise en charge via /vsizip/.