### PR TITLE
Améliore le log de sortie en production

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "import": "grunt import",
     "test": "npm run lint && npm run test-unit",
-    "test-unit": "istanbul cover _mocha",
+    "test-unit": "NODE_ENV=test istanbul cover _mocha -- -t 5000",
     "lint": "eslint controllers/**/*.js helpers/**/*/js *.js test/**/*.js lib/**/*.js",
     "start": "node server"
   },

--- a/server.js
+++ b/server.js
@@ -16,7 +16,16 @@ var port = process.env.PORT || 8091;
 
 app.use(bodyParser.json());
 app.use(cors());
-app.use(morgan(process.env.NODE_ENV === 'production' ? 'short' : 'dev'));
+
+var env = process.env.NODE_ENV;
+
+if (env === 'production') {
+    app.use(morgan(':date[clf] :req[x-real-ip] :method :url HTTP/:http-version :status :res[content-length] - :response-time ms'));
+}
+
+if (env === 'development') {
+    app.use(morgan('dev'));
+}
 
 /* Middlewares */
 function pgClient(req, res, next) {


### PR DESCRIPTION
Ajout de l’IP réelle et de la date.
Pas de logs lorsque `NODE_ENV` n’est pas à `production` ou `development`.
Passe `NODE_ENV` à `test` pendant les tests unitaires.
Augmente le délai d’acceptation des tests unitaires (lenteur réseau).

Pas de revue nécessaire.
Merge + déploiement immédiat.