### PR TITLE
Mise à jour du référentiel des appellations viticoles (17 décembre 2015)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
         'communes-ign-metrocorse': refDataDir + '/COMMUNE_PARCELLAIRE_METROCORSE.zip',
         'communes-ign-reunion': refDataDir + '/COMMUNE_PARCELLAIRE_REUNION.zip',
         'communes-osm': refDataDir + '/communes-20150101-5m-shp.zip',
-        'appellations-viticoles': refDataDir + '/Appellation_20151208.zip'
+        'appellations-viticoles': refDataDir + '/Appellation_20151217.zip'
     };
 
     const rmdir = {};
@@ -50,7 +50,7 @@ module.exports = function (grunt) {
             select: 'insee,nom'
         },
         'appellations-viticoles': {
-            dataSource: '/vsizip/Appellation_20151208.zip',
+            dataSource: '/vsizip/Appellation_20151217.zip',
             layerName: 'appellation',
             convertToWgs84: true,
             spatialIndex: 'NO',


### PR DESCRIPTION
> Suite à une nouvelle livraison coté INAO, nous avons désormais 3763
vecteurs et 9023 non vecteurs en segment 1, et toujours 31348 segments 3
et 36550 segment 4.