### PR TITLE
Gestion des logs avec bunyan

### DIFF
--- a/lib/request-logger.js
+++ b/lib/request-logger.js
@@ -1,0 +1,41 @@
+const bunyan = require('bunyan');
+const uuid = require('node-uuid');
+const onFinished = require('on-finished');
+const _ = require('lodash');
+
+
+module.exports = function () {
+    const logger = bunyan.createLogger({
+        name: 'request'
+    });
+
+    return function (req, res, next) {
+        // Start request duration counter
+        const startTime = Date.now();
+
+        // Define request id
+        req.reqId = uuid.v4();
+
+        const payload = {
+            reqId: req.reqId,
+            method: req.method,
+            path: req.path,
+            agent: req.headers['user-agent'],
+            remote: req.ip || (req.connection && req.connection.remoteAddress)
+        };
+
+        // Query string
+        const query = _.omit(req.query, 'geom');
+        if (req.query.geom) query.geom = 'provided';
+        if (Object.keys(query).length > 0) payload.query = query;
+
+        onFinished(res, function (err, res) {
+            payload.code = res.statusCode;
+            payload.duration = Date.now() - startTime;
+            if (res.getHeader('content-length')) payload.size = res.getHeader('content-length');
+            logger.info(payload);
+        });
+
+        next();
+    };
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run lint && npm run test-unit",
     "test-unit": "NODE_ENV=test istanbul cover _mocha -- -t 5000",
     "lint": "eslint controllers/**/*.js helpers/**/*/js *.js test/**/*.js lib/**/*.js",
-    "start": "node server"
+    "start": "node server | bunyan"
   },
   "contributors": [
     "Jérôme Desboeufs <jerome.desboeufs@data.gouv.fr>",
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "body-parser": "^1.14.1",
+    "bunyan": "^1.5.1",
     "codes-postaux": "^1.0.1",
     "cors": "^2.7.1",
     "debug": "^2.2.0",
@@ -33,7 +34,7 @@
     "grunt-shell": "^1.1.2",
     "handlebars": "^4.0.3",
     "lodash": "^3.10.1",
-    "morgan": "^1.6.1",
+    "node-uuid": "^1.4.7",
     "on-finished": "^2.3.0",
     "pg": "^4.4.3",
     "pg-format": "0.1.4",

--- a/server.js
+++ b/server.js
@@ -3,7 +3,6 @@ var _ = require('lodash');
 var bodyParser = require('body-parser');
 var cors = require('cors');
 var pg = require('pg');
-var morgan = require('morgan');
 var onFinished = require('on-finished');
 var communesHelper = require('./helpers/communes');
 var aoc = require('./controllers/aoc');
@@ -27,13 +26,10 @@ app.use(
 var env = process.env.NODE_ENV;
 
 if (env === 'production') {
-    morgan.token('real-ip', req => req.headers['x-forwarded-for'].split(',')[0]);
-    app.use(morgan(':date[clf] :real-ip :method :url HTTP/:http-version :status :res[content-length] - :response-time ms - :user-agent'));
+    app.enable('trust proxy');
 }
 
-if (env === 'development') {
-    app.use(morgan('dev'));
-}
+app.use(require('./lib/request-logger')());
 
 /* Middlewares */
 function pgClient(req, res, next) {
@@ -57,8 +53,6 @@ app.use('/cadastre', cadastre({
 }));
 
 /* Ready! */
-app.listen(port, function () {
-    console.log('Start listening on port %d', port);
-});
+app.listen(port);
 
 module.exports = app;


### PR DESCRIPTION
En relation avec #11 

Créé un logger `bunyan` pour tracker les requêtes entrantes :
- `reqId` :  identifiant unique de requête
- `method` : méthode de la requête
- `path` : chemin
- `agent` : User-Agent
- `remote` : IP
- `query` : critères de recherche, avec filtrage du champ `geom`
- `code` : code de retour
- `duration` : durée d'exécution
- `size` : taille non compressée de la réponse

Remplace `morgan` qui était une simple sortie texte.