### PR TITLE
ajout parametre com_abs dans result geometrie

### DIFF
--- a/lib/geom_featurecollection.js
+++ b/lib/geom_featurecollection.js
@@ -27,6 +27,7 @@ function geom_featureCollection(parcelles, paramGeom){
                 code_dep: parcelle.properties.code_dep,
                 nom_com: parcelle.properties.nom_com,
                 code_com: parcelle.properties.code_com,
+                com_abs: parcelle.properties.com_abs,
                 code_arr: parcelle.properties.code_arr
             }
         };

--- a/test/geometrie.js
+++ b/test/geometrie.js
@@ -40,6 +40,7 @@ describe('test du module geometrie  ', function() {
                             code_dep: '07',
                             nom_com: 'Andance',
                             code_com: '009',
+                            com_abs: '000',
                             code_arr: '000' 
                         });
                     })


### PR DESCRIPTION
Ajout champ supplémentaire com_abs: champ manquant dans le retour de la géometrie suite remontée erreur FranceAgrimer