### PR TITLE
Correction de la documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "pg": "^4.4.3",
     "pg-format": "0.1.4",
     "request": "2.65.0",
-    "swagger-ui": "^2.1.3",
+    "swagger-ui": "2.1.3",
     "terraformer-wkt-parser": "1.0.1",
     "turf": "^2.0.2"
   },


### PR DESCRIPTION
La version de `swagger-ui` était trop souple.
`2.1.4` inconsistante avec `2.1.3` :(