### PR TITLE
Search organisme

### DIFF
--- a/controllers/dila-organisme.js
+++ b/controllers/dila-organisme.js
@@ -11,8 +11,8 @@ exports.search = function(req, res, next) {
     var sql = `SELECT 
                   o.type,o.nom, o.insee,o.source,o.maj,o.url,o.telephone,o.telecopie,o.email,o.ouvertures,o.adresse,
                   ST_AsGeoJSON(o.geometry) as geom
-              FROM dila.commune c LEFT JOIN dila.organisme o ON o.id = c.organisme_id 
-              WHERE c.insee='`+req.query.insee+`'`;
+              FROM 	dila.commune c LEFT JOIN dila.organisme o ON o.id = c.organisme_id 
+              WHERE c.insee="`+req.query.insee+`"`;
     req.pgClient.query(sql, function(err, result) {
         if (err) {
             req.pgEnd(err);

--- a/controllers/dila-organisme.js
+++ b/controllers/dila-organisme.js
@@ -12,7 +12,7 @@ exports.search = function(req, res, next) {
                   o.type,o.nom, o.insee,o.source,o.maj,o.url,o.telephone,o.telecopie,o.email,o.ouvertures,o.adresse,
                   ST_AsGeoJSON(o.geometry) as geom
               FROM 	dila.commune c LEFT JOIN dila.organisme o ON o.id = c.organisme_id 
-              WHERE c.insee="`+req.query.insee+`"`;
+              WHERE c.insee="${req.query.insee}"`;
     req.pgClient.query(sql, function(err, result) {
         if (err) {
             req.pgEnd(err);

--- a/controllers/dila-organisme.js
+++ b/controllers/dila-organisme.js
@@ -1,0 +1,38 @@
+var _ = require('lodash');
+
+exports.search = function(req, res, next) {
+
+    if (!req.query.insee) {
+        res.status(400).send({
+            status: 'Missing param Insee'
+        });
+    }
+      
+    var sql = `SELECT 
+                  o.type,o.nom, o.insee,o.source,o.maj,o.url,o.telephone,o.telecopie,o.email,o.ouvertures,o.adresse,
+                  ST_AsGeoJSON(o.geometry) as geom
+              FROM dila.commune c LEFT JOIN dila.organisme o ON o.id = c.organisme_id 
+              WHERE c.insee='`+req.query.insee+`'`;
+    req.pgClient.query(sql, function(err, result) {
+        if (err) {
+            req.pgEnd(err);
+            return next(err);
+        }
+       
+        if (!result.rows) {
+            return res.status(404).send({
+                status: 'No Data'
+            });
+        }
+        return res.send({
+            type: 'FeatureCollection',
+            features: result.rows.map(function(row) {
+                return {
+                    type: 'Feature',
+                    geometry: JSON.parse(row.geom),
+                    properties: _.omit(row, 'geom')
+                };
+            })
+        });
+    });
+};

--- a/lib/prepare-params-cadastre.js
+++ b/lib/prepare-params-cadastre.js
@@ -38,6 +38,22 @@ module.exports = function (req, res, next) {
                 });
             }
             break;
+        case 'prefixe':
+            if(query[name].length == 3) {
+                result.com_abs =  '\''+query[name]+'\'' ;
+            } else {
+                return res.status(400).send({
+                    code: 400,
+                    message:'Le prefixe est sur 3 caractères'
+                });
+            }
+            break;
+        case 'dep':
+            result.code_dep = '\''+query[name]+'\'' ;
+            break;
+        case 'nom_com':
+            result.nom_com = '\''+query[name]+'\'' ;
+            break;
         default:
             return res.status(400).send({
                 code: 400,

--- a/server.js
+++ b/server.js
@@ -9,6 +9,7 @@ var aoc = require('./controllers/aoc');
 var codesPostaux = require('./controllers/codes-postaux');
 var qp = require('./controllers/quartiers-prioritaires');
 var cadastre = require('./controllers/cadastre');
+var dilaOrganisme = require('./controllers/dila-organisme');
 
 var app = express();
 var port = process.env.PORT || 8091;
@@ -51,6 +52,7 @@ app.use('/cadastre', cadastre({
     key: process.env.GEOPORTAIL_KEY || process.env.npm_package_config_geoportailKey,
     referer: process.env.GEOPORTAIL_REFERER || process.env.npm_package_config_geoportailReferer || 'http://localhost'
 }));
+app.get('/dila/organisme/search', pgClient, dilaOrganisme.search);
 
 /* Ready! */
 app.listen(port);

--- a/test/commune.js
+++ b/test/commune.js
@@ -35,6 +35,75 @@ describe('test du module commune  ', function() {
                 })
                 .end(done);
         });
+        it('should reply a FeatureCollection containing a valid Feature', done => {
+            request(server)    
+                .get('/cadastre/commune?insee=55001')
+                .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        nom_com: 'Abainville',
+                        code_dep: '55',
+                        code_insee: '55001'
+                    });
+                })
+                .end(done);
+        });
+    });
+    
+    describe('Test du module commune avec valeur', function() {
+        it('should work for insee 94067', function(){
+            request(server)
+                .get('/cadastre/commune?insee=94067')
+                .expect(200);
+        });
+        it('should reply a FeatureCollection containing a valid Feature', done => {
+            request(server)    
+                .get('/cadastre/commune?insee=55001')
+                .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        nom_com: 'Abainville',
+                        code_dep: '55',
+                        code_insee: '55001'
+                    });
+                })
+                .end(done);
+        });
+         it('should work for dep 94 ', done => {
+            request(server)    
+                .get('/cadastre/commune?dep=94')
+                 .expect(200);
+        });
+        it('should work for dep 94 and nom_com Vincennes : Return FeatureCollection', done => {
+            request(server)    
+                .get('/cadastre/commune?dep=94&nom_com=Vincennes')
+               .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        nom_com: 'Vincennes',
+                        code_dep: '94',
+                        code_insee: '94080'
+                    });
+                })
+                .end(done);
+        });
+       /*it('should work for Paris 12e : Return FeatureCollection', done => {
+            request(server)    
+                .get('/cadastre/commune?insee=75056&prefixe')
+               .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        nom_com: 'Vincennes',
+                        code_dep: '94',
+                        code_insee: '94080'
+                    });
+                })
+                .end(done);
+        });*/
     });
 });
 


### PR DESCRIPTION
Ajout de fonctionnalités pour récupérer la liste de toutes les communes dans un departement et recherche par nom_commune
Utilisation des sources de données dila pour le positionnement de sources de données sur une carte. Il faut au préalable charger les données dila en utilisant le script: https://github.com/mborne/apicarto-integration/tree/master/datasets/dila.
Le script marche très bien mais il ne passe pas avec npm run lint à cause des ' et des ` 
