### PR TITLE
Maj param dep et code arrondissement

### DIFF
--- a/doc/cadastre.yml
+++ b/doc/cadastre.yml
@@ -114,7 +114,12 @@ paths:
           description: Code insee de la commune sur 5 caractères
           type: string
           pattern: '\d{5}'
-          required: true
+          required: false
+        - name: dep
+          in: query
+          description: Numéro département sur 2 ou 3 caractères(DOM)
+          type: string
+          required: false
       tags:
         - Commune
       responses:
@@ -141,6 +146,12 @@ paths:
           in: query
           description: Section de la parcelle sur 2 caractères
           pattern: '\w{2}'
+          type: string
+          required: false
+        - name: codearr
+          in: query
+          description: Code arrondisssement pour Paris, Lyon, Marseille
+          pattern: '\d{3}'
           type: string
           required: false
       tags:
@@ -175,6 +186,12 @@ paths:
           description: Numero de la parcelle sur 4 caractères
           type: string
           pattern: '\d{4}'
+          required: false
+        - name: codearr
+          in: query
+          description: Code arrondissement pour Paris, Lyon, Marseille
+          type: string
+          pattern: '\d{3}'
           required: false
       tags:
         - Parcelle
@@ -218,11 +235,18 @@ paths:
           description: Section de la parcelle
           type: string
           pattern: '\w{2}'
+          required: false
         - name: numero
           in: query
-          description: Numero de la parcelle sur 4 caractères
+          description: Numéro de la parcelle sur 4 caractères
           type: string
           pattern: '\d{4}'
+          required: false
+        - name: codearr
+          in: query
+          description: Code arrondissement pour Paris, Lyon, Marseille
+          type: string
+          pattern: '\d{3}'
           required: false
       responses:
         '200':

--- a/lib/prepare-params-cadastre.js
+++ b/lib/prepare-params-cadastre.js
@@ -38,6 +38,29 @@ module.exports = function (req, res, next) {
                 });
             }
             break;
+        case 'codearr': // Pour traiter le cas des arrondissements
+            if((query[name].length == 3) && (query[name].match(/[0-9]{2}/)))  {
+                result.code_arr =  '\''+query[name]+'\'' ;
+            } else {
+                return res.status(400).send({
+                    code: 400,
+                    message:'Le code arrondissement est composé de 3 chiffres'
+                });
+            }
+            break;
+        case 'dep':
+            if((query[name].length == 3) || (query[name].length == 2)) {
+                result.code_dep = '\''+query[name]+'\'' ;
+            } else {
+                return res.status(400).send({
+                    code: 400,
+                    message:'Le numéro de département est composé de 2 caractères ou 3 caractères(DOM)'
+                });
+            }
+            break;
+        case 'nom_com':
+            result.nom_com = '\''+query[name]+'\'' ;
+            break;
         default:
             return res.status(400).send({
                 code: 400,
@@ -48,3 +71,5 @@ module.exports = function (req, res, next) {
     req.cadastreParams = result;
     next();
 };
+
+

--- a/test/commune.js
+++ b/test/commune.js
@@ -38,3 +38,43 @@ describe('test du module commune  ', function() {
     });
 });
 
+describe('Test du module commune avec valeur', function() {
+        it('should work for insee 94067', function(){
+            request(server)
+                .get('/cadastre/commune?insee=94067')
+                .expect(200);
+        });
+        it('should reply a FeatureCollection containing a valid Feature', done => {
+            request(server)    
+                .get('/cadastre/commune?insee=55001')
+                .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        nom_com: 'Abainville',
+                        code_dep: '55',
+                        code_insee: '55001'
+                    });
+                })
+                .end(done);
+        });
+         it('should work for dep 94 ', function(){
+            request(server)    
+                .get('/cadastre/commune?dep=94')
+                 .expect(200);
+        });
+        it('should work for dep 94 and nom_com Vincennes : Return FeatureCollection', done => {
+            request(server)    
+                .get('/cadastre/commune?dep=94&nom_com=Vincennes')
+               .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        nom_com: 'Vincennes',
+                        code_dep: '94',
+                        code_insee: '94080'
+                    });
+                })
+                .end(done);
+        });
+    });

--- a/test/divisions.js
+++ b/test/divisions.js
@@ -46,5 +46,25 @@ describe('test du module divisions', function() {
                 })
                 .end(done);
         });
+        it('should reply a FeatureCollection containing a valid Feature for case Paris 12e', done => {
+            request(server)
+                .get('/cadastre/division?insee=75056&codearr=112&section=AA')
+                .expect(res => {
+                    const feature = res.body.features[0];
+                    expect(feature.geometry.type).to.eql('MultiPolygon');
+                    expect(feature.properties).to.eql({
+                        feuille: 1,
+                        section: 'AA',
+                        code_dep: '75',
+                        nom_com: 'Paris',
+                        code_com: '056',
+                        com_abs: '000',
+                        echelle: '500',
+                        edition: 3,
+                        code_arr: '112'
+                    });
+                })
+                .end(done);
+        });
     });
 });


### PR DESCRIPTION
Ajout de paramètres de recherche au niveau cadastre/commune avec le numéro dep
Ajout d'une recherche par code_arr qui permet la recherche par arrondissement sur Paris, Lyon, Marseille pour les divisions, parcelles et localisants.