### PR TITLE
Ajout possibilite recherche avec le parametre com_abs

### DIFF
--- a/doc/cadastre.yml
+++ b/doc/cadastre.yml
@@ -193,6 +193,12 @@ paths:
           type: string
           pattern: '\d{3}'
           required: false
+        - name: com_abs
+          in: query
+          description: Code commune absorbée
+          type: string
+          pattern: '\d{3}'
+          required: false
       tags:
         - Parcelle
 

--- a/lib/prepare-params-cadastre.js
+++ b/lib/prepare-params-cadastre.js
@@ -61,12 +61,24 @@ module.exports = function (req, res, next) {
         case 'nom_com':
             result.nom_com = '\''+query[name]+'\'' ;
             break;
+            
+        case 'com_abs': // Pour traiter le cas des communes rattachés et parcelles identiques
+            if((query[name].length == 3) && (query[name].match(/[0-9]{2}/)))  {
+                result.com_abs=  '\''+query[name]+'\'' ;
+            } else {
+                return res.status(400).send({
+                    code: 400,
+                    message:'Le prefixe est composé de 3 chiffres obligatoires'
+                });
+            }
+            break;
         default:
             return res.status(400).send({
                 code: 400,
                 message:'Un ou plusieurs paramètres sont inconnus'
             });
         }
+        
     }
     req.cadastreParams = result;
     next();

--- a/test/parcelle.js
+++ b/test/parcelle.js
@@ -15,10 +15,17 @@ describe('test du module parcelle', function() {
                 .expect(400,done);
         });
     });
-    describe('Test du module divisions avec valeur', function() {
+    describe('Test du module parcelles avec valeur', function() {
         it('should work for insee 94067 et section=0A', function(){
             request(server)
                 .get('/cadastre/parcelle?insee=94067&section=0A')
+                .expect(200);
+        });
+    });
+    describe('Test du module parcelles avec valeur', function() {
+        it('should work for insee 33290 et section=0A et numero=0112 et com_abs=410', function(){
+            request(server)
+                .get('/cadastre/parcelle?insee=94067&section=0A&numero=0112&com_abs=410')
                 .expect(200);
         });
     });


### PR DESCRIPTION
Pour faire face aux problèmes des communes rattachées, il se peut que dans certains cas nous ayons 2 parcelles identiques pour une commune. Il faudra donc utiliser dans ce cas, le code commune absorbée.